### PR TITLE
Fix app panic

### DIFF
--- a/main.go
+++ b/main.go
@@ -530,8 +530,21 @@ func main() {
 			ArgsUsage: "[method path]",
 			Flags:     []cli.Flag{},
 			Action: func(ctx *cli.Context) error {
+				err := setGlobalVars(ctx)
+				if err != nil {
+					return err
+				}
+
 				method := strings.ToUpper(ctx.Args().Get(0))
 				path := ctx.Args().Get(1)
+
+				if method == "" || path == "" {
+					message := "The method and path arguments are required: `timber api [method path]`\n" +
+						"Run `timber help api` for more details"
+					// Exit with 65, EX_DATAERR, to indicate input data was incorrect
+					return cli.NewExitError(message, 65)
+				}
+
 				return request(method, path, nil)
 			},
 		},

--- a/request.go
+++ b/request.go
@@ -1,24 +1,24 @@
 package main
 
 import (
-  "encoding/json"
-  "fmt"
+	"encoding/json"
+	"fmt"
 )
 
 func request(method string, path string, body interface{}) error {
-  response := json.RawMessage{}
+	response := json.RawMessage{}
 
-  err := client.Request(method, path, nil, nil, &response)
-  if err != nil {
-    return err
-  }
+	err := client.Request(method, path, nil, nil, &response)
+	if err != nil {
+		return err
+	}
 
-  json, err := json.MarshalIndent(response, "", "  ")
-  if err != nil {
-    logger.Fatal(err)
-  }
+	json, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		logger.Fatal(err)
+	}
 
-  fmt.Printf("%s\n", json)
+	fmt.Printf("%s\n", json)
 
-  return nil
+	return nil
 }


### PR DESCRIPTION
Fixes #4 

Separate commit runs the formatter on `request.go`, which was weird unformatted.

Also adds a help doc when required CLI args are missing.